### PR TITLE
Fix when jQuery is not defined

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -80,6 +80,7 @@ ElasticProgress.prototype=extend(
 );
 
 // jQuery plugin, in case jQuery is available
+var jQuery = jQuery || undefined;
 if(isSet(jQuery)){
   (function($){
     $.fn.ElasticProgress=function(optionsOrMethod){


### PR DESCRIPTION
As we are in strict mode, the previous code failed with
Uncaught ReferenceError: jQuery is not defined
as we tried to access a variable that is not defined.

This small fix makes sure to define the variable appropriately.
